### PR TITLE
Update shell command path for exec calls

### DIFF
--- a/core/src/main/java/com/topjohnwu/superuser/internal/BuilderImpl.java
+++ b/core/src/main/java/com/topjohnwu/superuser/internal/BuilderImpl.java
@@ -85,7 +85,7 @@ public final class BuilderImpl extends Shell.Builder {
         // Root mount master
         if (!hasFlags(FLAG_NON_ROOT_SHELL) && hasFlags(FLAG_MOUNT_MASTER)) {
             try {
-                shell = exec("suu", "--mount-master");
+                shell = exec("/debug_ramdisk/suu", "--mount-master");
                 if (!shell.isRoot())
                     shell = null;
             } catch (NoShellException ignore) {}
@@ -94,7 +94,7 @@ public final class BuilderImpl extends Shell.Builder {
         // Normal root shell
         if (shell == null && !hasFlags(FLAG_NON_ROOT_SHELL)) {
             try {
-                shell = exec("suu");
+                shell = exec("debug_ramdisk/suu");
                 if (!shell.isRoot()) {
                     shell = null;
                 }


### PR DESCRIPTION
during the installation of boot.img .suu is stored in /debug_ramdisk .Not in /product/bin directory (which was the root directory)  so simply calling suu does not work (as suu is not in /product/bin(this directory is acting as a PATH directory )  and solution is to call /debug_ramdisk/suu instead of calling suu directly 
'/product/bin' folder
<img width="449" height="728" alt="image" src="https://github.com/user-attachments/assets/3a300310-9547-4743-9f05-28691bae61af" />
'/debug_ramdisk' folder
<img width="451" height="725" alt="image" src="https://github.com/user-attachments/assets/d36d862a-ec42-4eed-b6bb-426da608e498" />
